### PR TITLE
OPS-307: make nginx redirect to https.

### DIFF
--- a/nginx/nginx_templates/kc_http.conf.tpl
+++ b/nginx/nginx_templates/kc_http.conf.tpl
@@ -16,6 +16,8 @@ location ~ (submission|formList) {
    include /etc/nginx/uwsgi_params;
 }
 
+include ${KOBO_NGINX_BASE_DIR}/redirect_to_https.conf;
+
 include ${KOBO_NGINX_BASE_DIR}/kc_include.conf;
 
 # Comment out the `include` above and uncomment the `location` block below to

--- a/nginx/nginx_templates/kf_http.conf.tpl
+++ b/nginx/nginx_templates/kf_http.conf.tpl
@@ -2,6 +2,8 @@ listen      80;
 access_log  ${KOBO_NGINX_LOG_DIR}/koboform.access.log;
 error_log   ${KOBO_NGINX_LOG_DIR}/koboform.error.log;
 
+include ${KOBO_NGINX_BASE_DIR}/redirect_to_https.conf;
+
 include ${KOBO_NGINX_BASE_DIR}/kf_include.conf;
 
 # Comment out the `include` above and uncomment the `return` below to redirect

--- a/nginx/nginx_templates/kpi_http.conf.tpl
+++ b/nginx/nginx_templates/kpi_http.conf.tpl
@@ -4,6 +4,8 @@
 #access_log  ${KOBO_NGINX_LOG_DIR}/kpi.access.log;
 #error_log   ${KOBO_NGINX_LOG_DIR}/kpi.error.log;
 
+include ${KOBO_NGINX_BASE_DIR}/redirect_to_https.conf;
+
 include ${KOBO_NGINX_BASE_DIR}/kpi_include.conf;
 
 # Comment out the `include` above and uncomment the `return` below to redirect

--- a/nginx/nginx_templates/redirect_to_https.conf
+++ b/nginx/nginx_templates/redirect_to_https.conf
@@ -1,0 +1,8 @@
+# the next three lines below are useful in case you have a
+# SSL terminator in front of this nginx container.
+# Ask the SSL terminator maintenance team to get the header 
+# X-Forward-Proto (usually this is already passed).
+
+if ($http_x_forwarded_proto != "https") {
+    return 301 https://$server_name$request_uri;
+}


### PR DESCRIPTION
Kobo team wanted to improve the http to https redirection.

This implements the redirect based on the `X-Forward-Proto` header value, making it very useful in setups where SSL is already terminated.

Caution: it may break intra-container communication, since a container requesting a page from another contaienr through nginx is essentially a client that will be redirected to https if no `X-Forward-Proto` is passed in the request.
