### PR TITLE
Make nginx redirect to https

### DIFF
--- a/nginx/nginx_templates/kc_http.conf.tpl
+++ b/nginx/nginx_templates/kc_http.conf.tpl
@@ -16,6 +16,8 @@ location ~ (submission|formList) {
    include /etc/nginx/uwsgi_params;
 }
 
+include ${KOBO_NGINX_BASE_DIR}/redirect_to_https.conf;
+
 include ${KOBO_NGINX_BASE_DIR}/kc_include.conf;
 
 # Comment out the `include` above and uncomment the `location` block below to

--- a/nginx/nginx_templates/kc_http.conf.tpl
+++ b/nginx/nginx_templates/kc_http.conf.tpl
@@ -18,10 +18,27 @@ location ~ (submission|formList) {
 
 include ${KOBO_NGINX_BASE_DIR}/redirect_to_https.conf;
 
-include ${KOBO_NGINX_BASE_DIR}/kc_include.conf;
+#include ${KOBO_NGINX_BASE_DIR}/kc_include.conf;
 
 # Comment out the `include` above and uncomment the `location` block below to
 # redirect all non-ODK-Collect requests to HTTPS
 #location / {
 #   return 301 https://%server_name%request_uri;
 #}
+
+location /static {
+    alias /srv/www/kobocat;
+}
+
+location / {
+    if (%maintenance = "yes") {
+        rewrite .* http://${KOBO_PREFIX}kobo.${KOBO_DOMAIN};
+    }
+    uwsgi_read_timeout 130;
+    uwsgi_send_timeout 130;
+    uwsgi_pass kobocat;
+    include /etc/nginx/uwsgi_params;
+
+    include ${KOBO_NGINX_BASE_DIR}/redirect_to_https.conf;
+
+}

--- a/nginx/nginx_templates/kf_http.conf.tpl
+++ b/nginx/nginx_templates/kf_http.conf.tpl
@@ -2,6 +2,8 @@ listen      80;
 access_log  ${KOBO_NGINX_LOG_DIR}/koboform.access.log;
 error_log   ${KOBO_NGINX_LOG_DIR}/koboform.error.log;
 
+include ${KOBO_NGINX_BASE_DIR}/redirect_to_https.conf;
+
 include ${KOBO_NGINX_BASE_DIR}/kf_include.conf;
 
 # Comment out the `include` above and uncomment the `return` below to redirect

--- a/nginx/nginx_templates/kpi_http.conf.tpl
+++ b/nginx/nginx_templates/kpi_http.conf.tpl
@@ -4,6 +4,8 @@
 #access_log  ${KOBO_NGINX_LOG_DIR}/kpi.access.log;
 #error_log   ${KOBO_NGINX_LOG_DIR}/kpi.error.log;
 
+include ${KOBO_NGINX_BASE_DIR}/redirect_to_https.conf;
+
 include ${KOBO_NGINX_BASE_DIR}/kpi_include.conf;
 
 # Comment out the `include` above and uncomment the `return` below to redirect

--- a/nginx/nginx_templates/redirect_to_https.conf
+++ b/nginx/nginx_templates/redirect_to_https.conf
@@ -1,0 +1,8 @@
+# the next three lines below are useful in case you have a
+# SSL terminator in front of this nginx container.
+# Ask the SSL terminator maintenance team to get the header 
+# X-Forward-Proto (usually this is already passed).
+
+if ($http_x_forwarded_proto != "https") {
+    return 301 https://$server_name$request_uri;
+}

--- a/nginx/nginx_templates/redirect_to_https.conf
+++ b/nginx/nginx_templates/redirect_to_https.conf
@@ -1,8 +1,10 @@
 # the next three lines below are useful in case you have a
 # SSL terminator in front of this nginx container.
-# Ask the SSL terminator maintenance team to get the header 
+# Ask the SSL terminator maintenance team to provide you the header 
 # X-Forward-Proto (usually this is already passed).
 
 if ($http_x_forwarded_proto != "https") {
+    # here, unfortunately, if you have a POST call over http it will fail
+    # see https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html on 301.
     return 301 https://$server_name$request_uri;
 }


### PR DESCRIPTION
this change will attempt to detect `X-Forwarded-Proto` on each request on HTTP and if exists and is equal to `https`, it will NOT redirect to https.
