### PR TITLE
Remove KC Celery command line limits

### DIFF
--- a/kobocat/run_celery
+++ b/kobocat/run_celery
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-CELERYD_OPTIONS='--loglevel=DEBUG --time-limit=900 --maxtasksperchild=5'
+CELERYD_OPTIONS='--loglevel=DEBUG'
 
 cd /srv/src/kobocat
 


### PR DESCRIPTION
in favor of those specified in Django settings / environment variables.
Companion to https://github.com/kobotoolbox/kobocat/pull/256
