### PR TITLE
Include `libffi-dev`, required for SNI support

### DIFF
--- a/base-kobos/Dockerfile
+++ b/base-kobos/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qq update && \
         libxml2-dev \
         libxslt1-dev \
         libjpeg-dev \
+        libffi-dev \
         nodejs \
         npm \
         postgresql-client-9.3 \


### PR DESCRIPTION
New Python packages need to be installed for the `requests` library to support the SNI configuration used on staging server `mp03`. This development package is a prerequisite of https://github.com/kobotoolbox/dkobo/pull/636.
