### PR TITLE
Update `base-kobos` packages

### DIFF
--- a/base-kobos/Dockerfile
+++ b/base-kobos/Dockerfile
@@ -2,7 +2,8 @@ FROM teodorescuserban/kobo-base:latest
 
 MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
 
-RUN apt-get -qq update && \
+RUN curl -sL 'https://deb.nodesource.com/setup_6.x' | bash && \
+    apt-get -qq update && \
     apt-get -qq -y install \
         binutils \
         default-jre-headless \
@@ -17,14 +18,11 @@ RUN apt-get -qq update && \
         libjpeg-dev \
         libffi-dev \
         nodejs \
-        npm \
-        postgresql-client-9.3 \
         python2.7-dev \
         python-qgis \
         qgis && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    ln -s /usr/bin/nodejs /usr/bin/node && \
     mkdir -p /etc/service/wsgi && \
     touch /etc/service/wsgi/run && \
     curl -s https://bootstrap.pypa.io/get-pip.py -o /get-pip.py && \


### PR DESCRIPTION
- Remove obsolete Postgres 9.3 client
- Upgrade to Node 6.x (also upgrades NPM)
