### PR TITLE
Specify KPI max upload size in `location` block

### DIFF
--- a/nginx/nginx_templates/kpi_include.conf.tpl
+++ b/nginx/nginx_templates/kpi_include.conf.tpl
@@ -28,6 +28,10 @@ location /forms/ {
     if (%maintenance = "yes") {
         return 418;
     }
+
+    # max upload size
+    client_max_body_size 75M;
+
     uwsgi_read_timeout 130;
     uwsgi_send_timeout 130;
     uwsgi_pass kpi;


### PR DESCRIPTION
Fixes 413 error when clients try to upload >1M