### PR TITLE
Pass along `X-Forwarded-For` header

### DIFF
--- a/nginx/nginx_templates/kpi_include.conf.tpl
+++ b/nginx/nginx_templates/kpi_include.conf.tpl
@@ -37,5 +37,6 @@ location /forms/ {
     uwsgi_read_timeout 130;
     uwsgi_send_timeout 130;
     uwsgi_pass kpi;
+    uwsgi_param HTTP_X_FORWARDED-FOR $proxy_add_x_forwarded_for;
     include /etc/nginx/uwsgi_params;
 }


### PR DESCRIPTION
Needed for kobotoolbox/kpi#1128, which requires:

1. HAProxy removes the `X-Forwarded-For` HTTP header from inbound client requests
2. HAProxy sets the `X-Forwarded-For` HTTP header to the client's IP address
3. Nginx preserves the client IP in the `X-Forwarded-For` HTTP header and passes it along to Django.

This PR takes care of item 3.